### PR TITLE
error found

### DIFF
--- a/Backend/API Documentation/Api auth.txt
+++ b/Backend/API Documentation/Api auth.txt
@@ -97,8 +97,8 @@ Status code 500/   - ошибка сервера
 Body
     {
       "id": "1",
-      "a uthor": "1",
-      "languag": "1",
+      "author": "1",
+      "language": "1",
       "title": "Meta Book Title",
       "create_date": "2000",
       "size": "500",


### PR DESCRIPTION
В папке Backend, в файле auth.txt были обнаружены ошибки в 5  пункте

5. POST /admin/insertMetabook - Добавление записи в Metabooks
Body
    {
      "id": "1",
      "a uthor": "1",                        ---- присутствует пробел
      "languag": "1",                      ---- отсутствует буква
      "title": "Meta Book Title",
      "create_date": "2000",
      "size": "500",
      "owner": "1"
    }
    
    